### PR TITLE
[#157032509] Set the Subject Key Identifier when generating certificates

### DIFF
--- a/types/certificate_generator.go
+++ b/types/certificate_generator.go
@@ -1,10 +1,13 @@
 package types
 
 import (
+	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha1"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"math/big"
 	"net"
@@ -84,6 +87,10 @@ func (cfg CertificateGenerator) generateCertificate(cParams certParams) (CertRes
 
 	if cParams.IsCA {
 		certTemplate.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageCRLSign
+		certTemplate.SubjectKeyId, err = generateSubjectKeyID(&privateKey.PublicKey)
+		if err != nil {
+			return certResponse, errors.WrapError(err, "Generating Subject Key ID")
+		}
 
 		signingKey := privateKey
 		signingCA := &certTemplate
@@ -104,6 +111,10 @@ func (cfg CertificateGenerator) generateCertificate(cParams certParams) (CertRes
 			return certResponse, errors.Error("Missing required CA name")
 		}
 		certTemplate.KeyUsage = x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature
+		certTemplate.SubjectKeyId, err = generateSubjectKeyID(&privateKey.PublicKey)
+		if err != nil {
+			return certResponse, errors.WrapError(err, "Generating Subject Key ID")
+		}
 
 		extKeyUsages := certTemplate.ExtKeyUsage
 		if len(cParams.ExtKeyUsage) != 0 {
@@ -214,4 +225,20 @@ func objToStruct(input interface{}, str interface{}) error {
 	}
 
 	return nil
+}
+
+// GenerateSubjectKeyID generates a Subject Key Identifier for a certificate
+// The identifier is the 160-bit SHA-1 hash of the public key
+func generateSubjectKeyID(pub crypto.PublicKey) ([]byte, error) {
+	switch pub := pub.(type) {
+	case *rsa.PublicKey:
+		pubBytes, err := asn1.Marshal(*pub)
+		if err != nil {
+			return nil, err
+		}
+		hash := sha1.Sum(pubBytes)
+		return hash[:], nil
+	default:
+		return nil, errors.Error("only RSA public key is supported")
+	}
 }

--- a/types/certificate_generator_test.go
+++ b/types/certificate_generator_test.go
@@ -133,6 +133,11 @@ sHx2rlaLkmSreYJsmVaiSp0E9lhdympuDF+WKRolkQ==
 						Expect(certificate.ExtKeyUsage).To(BeEmpty())
 					})
 
+					It("sets SubjectKeyId", func() {
+						Expect(certificate.SubjectKeyId).ToNot(BeNil())
+						Expect(certificate.SubjectKeyId).To(HaveLen(20))
+					})
+
 					It("sets Issuer, Country & Org", func() {
 						Expect(certificate.Issuer.Country).To(Equal([]string{"USA"}))
 						Expect(certificate.Issuer.Organization).To(Equal([]string{"Cloud Foundry"}))
@@ -158,6 +163,11 @@ sHx2rlaLkmSreYJsmVaiSp0E9lhdympuDF+WKRolkQ==
 					It("sets KeyUsage and ExtKeyUsage", func() {
 						Expect(certificate.KeyUsage).To(Equal(x509.KeyUsageCertSign | x509.KeyUsageCRLSign))
 						Expect(certificate.ExtKeyUsage).To(BeEmpty())
+					})
+
+					It("sets SubjectKeyId", func() {
+						Expect(certificate.SubjectKeyId).ToNot(BeNil())
+						Expect(certificate.SubjectKeyId).To(HaveLen(20))
 					})
 
 					It("sets Issuer Country & Org", func() {


### PR DESCRIPTION
## What

The identifier is the 160-bit SHA-1 hash of the public key (see [1]).

This library is used by the BOSH cli and the BOSH cli can be used to generate
certificates into a variable store - based on the manifest variable definitons.
There is a known issue if you try to rotate the CA certificates outlined in [2].

The root of the problem is that when OpenSSL is configured to trust multiple
CAs, and two of them have the same subject name, OpenSSL will only verify
certificates against the first one (see [3] in OpenSSL code).

One solution for the CA certificate rotation problem is to set the Subject Key
Identifiers so OpenSSL will be able to handle multiple certificates with the
same subject name.

The generation method is based on certstrap's solution. [4]

[1] https://tools.ietf.org/html/rfc5280#section-4.2.1.2
[2] https://docs.google.com/document/d/1vKxziTEvIgKHubukoyAGaJzGqrMBjun7JffbunlLBPg/edit#heading=h.wftyivqbaag4
[3] https://github.com/openssl/openssl/blob/49f6cb968ff63793f6671d9026fb2a7034dad79a/crypto/x509/x509_lu.c#L613-L617
[4] https://github.com/square/certstrap/blob/b6aef507a0840bf78bac99e7ffa6e6eb5c2c3c9f/pkix/key.go#L150

## How to review

Code review

## Who can review it

Not me.